### PR TITLE
Downgrade to java 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ and choose `Flowdock Notifications Plugin` in either: "On Success", "On Failure"
 After the plugin will be selected there are few parameters to be specified:
 
 * Flowdock Flow Token (mandatory) - this will direct the notification to a specific flow (identified by the token)
-* Tags (optional) - can be entered to make the Flowdock search much easier
+* Tags (optional) - can be entered to make the Flowdock search much easier, plugin expects tags to be separated with space(s),
+  the initial hash sign (`#`) before each tag is optional - it will be added if needed.
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
@@ -35,8 +41,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 

--- a/src/main/java/com/lgi/rundeck/plugins/flowdock/FlowdockMessageSender.java
+++ b/src/main/java/com/lgi/rundeck/plugins/flowdock/FlowdockMessageSender.java
@@ -1,16 +1,21 @@
 package com.lgi.rundeck.plugins.flowdock;
 
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class FlowdockMessageSender {
+
+    private static final Splitter SPACE_SPLITTER = Splitter.on(" ").trimResults().omitEmptyStrings();
+    private static final Joiner COMMA_JOINER = Joiner.on(",");
 
     private final URI apiUrl = URI.create("https://api.flowdock.com/messages");
     private final String sender;
@@ -21,7 +26,7 @@ public class FlowdockMessageSender {
         this.flowToken = flowToken;
     }
 
-    public void postData(String message, Optional<String> maybeTags) throws IOException {
+    public void postData(String message, String tags) throws IOException {
 
         final HttpURLConnection conn = (HttpURLConnection) apiUrl.toURL().openConnection();
 
@@ -32,7 +37,7 @@ public class FlowdockMessageSender {
         conn.setRequestProperty("User-Agent", getClass().getSimpleName());
         conn.setRequestProperty("Content-Type", "application/json");
 
-        final String request = buildRequest(flowToken, message, maybeTags);
+        final String request = buildRequest(flowToken, message, tags);
 
         try (OutputStreamWriter out = new OutputStreamWriter(conn.getOutputStream())) {
             out.write(request);
@@ -45,13 +50,28 @@ public class FlowdockMessageSender {
 
     }
 
-    private static String buildRequest(String flowToken, String message, Optional<String> maybeTags) {
+    private static String buildRequest(String flowToken, String message, String tags) {
 
-        final String tagsToBeSent = maybeTags
-                .map(tags -> tags.split("\\s+"))
-                .filter(tags -> tags.length > 0)
-                .map(tags -> Stream.of(tags).map(tag -> String.format("\"%s\"", tag)).collect(Collectors.joining(",", "\"tags\": [", "],")))
-                .orElse("");
+        final String tagsToBeSent;
+        if (tags != null) {
+            final Iterable<String> parsedTags = SPACE_SPLITTER.split(tags);
+            final Iterable<String> transformedTags = Iterables.transform(parsedTags, new Function<String, String>() {
+                @Override
+                public String apply(String s) {
+                    return s.startsWith("#") ?
+                            String.format("\"%s\"", s) :
+                            String.format("\"#%s\"", s);
+                }
+            });
+
+            if (transformedTags.iterator().hasNext()) {
+                tagsToBeSent = String.format("\"tags\": [%s],", COMMA_JOINER.join(transformedTags));
+            } else {
+                tagsToBeSent = "";
+            }
+        } else {
+            tagsToBeSent = "";
+        }
 
         return String.format(
                 "{\"flow_token\": \"%s\", \"event\": \"message\", %s \"content\": \"%s\"}",

--- a/src/main/java/com/lgi/rundeck/plugins/flowdock/FlowdockNotificationPlugin.java
+++ b/src/main/java/com/lgi/rundeck/plugins/flowdock/FlowdockNotificationPlugin.java
@@ -7,7 +7,6 @@ import com.dtolabs.rundeck.plugins.notification.NotificationPlugin;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Optional;
 
 @Plugin(service = "Notification", name = "flowdock-notifications")
 @PluginDescription(title = "Flowdock Notifications Plugin", description = "Notifies a flow on a job status change.")
@@ -27,7 +26,7 @@ public class FlowdockNotificationPlugin implements NotificationPlugin {
 
         final FlowdockMessageSender sender = new FlowdockMessageSender("Rundeck", flowToken);
         try {
-            sender.postData(message, Optional.ofNullable(tags));
+            sender.postData(message, tags);
         } catch (IOException e) {
             throw new RuntimeException("Couldn't send message: " + message + " to FlowDock");
         }


### PR DESCRIPTION
Besides:

* tags don't need to be prepended with `#`
* README updated to describe, how tags should be passed